### PR TITLE
How to fetch piece and color by square, not xy

### DIFF
--- a/test_pieces.py
+++ b/test_pieces.py
@@ -570,6 +570,24 @@ class Board(object):
         get_moves = piece_functions[code.lower()]
         return set(get_moves(board, square, color))
 
+    def _code_at_square(self, square):
+        letter, number = square
+        x = column_names.index(letter)
+        y = row_names.index(number)
+        return self.rows[y][x]
+
+    def piece_at_square(self, square):
+        code = self._code_at_square(square)
+        return code.lower()
+
+    def color_at_square(self, square):
+        code = self._code_at_square(square)
+        if code.is_upper():
+            return White
+        if code.is_lower():
+            return Black
+        return None
+
     def color_at(self, x, y):
         code = self.rows[y][x]
         return None if code == '.' else White if code.isupper() else Black


### PR DESCRIPTION
You have made really good progress towards the is-the-king-in-check function! But I keep getting confused while reading it about all of the `x` and `y` values, so I think it is time to start moving the code towards always using square designations like `c4` and `e8`. This pull request suggests how you could entirely hide the `x` and `y` behind a few new `Board` methods that, I think, would let your in-check code just glide along using columns and ranks and never having to use `x` or `y` at all. Try changing your code over to just using square names and see what happens!
